### PR TITLE
add SSH remote workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This extension provides workspace search functionality for Zed within Flow Launcher with the default keyword 'z'.
 
-This extension also provides WSL support!
+This extension supports:
+- **Windows local workspaces**
+- **WSL workspaces**
+- **SSH remote workspaces**
 
 ![image](./assets/search-example-fix.png)
 

--- a/main.py
+++ b/main.py
@@ -15,8 +15,22 @@ ZED_DB_PATH = Path.home() / "AppData/Local/Zed/db/0-stable/db.sqlite"
 
 
 def is_wsl_path(p: str) -> bool:
-    """Detect whether a path belongs to WSL."""
+    """Detect whether a path belongs to WSL (only when not an SSH remote)."""
     return p.startswith("/home/") or p.startswith("/mnt/")
+
+
+def build_ssh_uri(
+    host: str, path: str, user: str | None = None, port: int | None = None
+) -> str:
+    """Build SSH URI for Zed: ssh://[user@]host[:port]/path"""
+    uri = "ssh://"
+    if user:
+        uri += f"{user}@"
+    uri += host
+    if port:
+        uri += f":{port}"
+    uri += path
+    return uri
 
 
 def normalize(p: str) -> str:
@@ -41,48 +55,59 @@ class ZedWorkspaceSearch(FlowLauncher):
             con = sqlite3.connect(ZED_DB_PATH)
             cur = con.cursor()
 
-            cur.execute("SELECT workspace_id, paths FROM workspaces")
+            # JOIN with remote_connections to get SSH info
+            cur.execute("""
+                SELECT 
+                    w.workspace_id, 
+                    w.paths,
+                    rc.kind,
+                    rc.host,
+                    rc.port,
+                    rc.user
+                FROM workspaces w
+                LEFT JOIN remote_connections rc ON w.remote_connection_id = rc.id
+            """)
             rows = cur.fetchall()
             con.close()
 
             by_normalized = {}
-
             by_workspace_id = {}
 
-            for wid, path in rows:
+            for wid, path, rc_kind, rc_host, rc_port, rc_user in rows:
                 if not path or not isinstance(path, str):
                     continue
 
                 norm = normalize(path)
 
+                # Determine connection type
+                is_ssh = rc_kind == "ssh" and rc_host is not None
+                # Only consider WSL if NOT an SSH remote
+                is_wsl = not is_ssh and is_wsl_path(path)
+
+                workspace_data = {
+                    "id": wid,
+                    "path": path,
+                    "normalized": norm,
+                    "is_wsl": is_wsl,
+                    "is_ssh": is_ssh,
+                    "ssh_host": rc_host if is_ssh else None,
+                    "ssh_user": rc_user if is_ssh else None,
+                    "ssh_port": rc_port if is_ssh else None,
+                }
+
                 # If we've already seen this normalized path, prefer the earliest record
                 if norm not in by_normalized:
-                    by_normalized[norm] = {
-                        "id": wid,
-                        "path": path,
-                        "normalized": norm,
-                        "is_wsl": is_wsl_path(path),
-                    }
+                    by_normalized[norm] = workspace_data
                 else:
                     existing = by_normalized[norm]["path"]
                     if len(path) < len(existing):
-                        by_normalized[norm] = {
-                            "id": wid,
-                            "path": path,
-                            "normalized": norm,
-                            "is_wsl": is_wsl_path(path),
-                        }
+                        by_normalized[norm] = workspace_data
 
                 # track shortest path per workspace_id as fallback
                 if wid not in by_workspace_id or len(path) < len(
                     by_workspace_id[wid]["path"]
                 ):
-                    by_workspace_id[wid] = {
-                        "id": wid,
-                        "path": path,
-                        "normalized": norm,
-                        "is_wsl": is_wsl_path(path),
-                    }
+                    by_workspace_id[wid] = workspace_data
 
             # Prefer the normalized-set
             results = (
@@ -97,7 +122,14 @@ class ZedWorkspaceSearch(FlowLauncher):
             return results
 
         except Exception as e:
-            return [{"id": -1, "path": f"<Error reading DB: {e}>", "is_wsl": False}]
+            return [
+                {
+                    "id": -1,
+                    "path": f"<Error reading DB: {e}>",
+                    "is_wsl": False,
+                    "is_ssh": False,
+                }
+            ]
 
     def query(self, query):
         q = query.lower().strip()
@@ -118,15 +150,20 @@ class ZedWorkspaceSearch(FlowLauncher):
 
         results = []
         for w in filtered:
-            # Use the path's last part for name
+            # Use the path's last part for name, capitalize it
             try:
                 name = Path(w["path"]).name or w["path"]
+                # Capitalize the project name
+                name = name.capitalize() if name else name
             except Exception:
                 name = w["path"]
 
-            # Label WSL workspaces clearly
-            if w["is_wsl"]:
-                title = f"{name}  (WSL)"
+            # Label SSH and WSL workspaces clearly
+            if w.get("is_ssh"):
+                ssh_host = w.get("ssh_host", "remote")
+                title = f"{name} (SSH: {ssh_host})"
+            elif w.get("is_wsl"):
+                title = f"{name} (WSL)"
             else:
                 title = name
 
@@ -137,9 +174,21 @@ class ZedWorkspaceSearch(FlowLauncher):
                     "IcoPath": "assets/zed.png",
                     "JsonRPCAction": {
                         "method": "open_workspace",
-                        "parameters": [w["path"]],
+                        "parameters": [
+                            w["path"],
+                            w.get("is_ssh", False),
+                            w.get("ssh_host"),
+                            w.get("ssh_user"),
+                            w.get("ssh_port"),
+                        ],
                     },
-                    "ContextData": [w["path"]],
+                    "ContextData": [
+                        w["path"],
+                        w.get("is_ssh", False),
+                        w.get("ssh_host"),
+                        w.get("ssh_user"),
+                        w.get("ssh_port"),
+                    ],
                 }
             )
 
@@ -153,7 +202,19 @@ class ZedWorkspaceSearch(FlowLauncher):
 
         return unique
 
-    def open_workspace(self, path):
+    def open_workspace(
+        self, path, is_ssh=False, ssh_host=None, ssh_user=None, ssh_port=None
+    ):
+        # SSH remote - use zed ssh://[user@]host[:port]/path
+        if is_ssh and ssh_host:
+            ssh_uri = build_ssh_uri(ssh_host, path, ssh_user, ssh_port)
+            subprocess.Popen(
+                ["zed", ssh_uri],
+                shell=False,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            return
+
         if is_wsl_path(path):
             # Open inside WSL
             subprocess.Popen(
@@ -174,9 +235,17 @@ class ZedWorkspaceSearch(FlowLauncher):
 
     def context_menu(self, data):
         path = data[0]
-        is_wsl = is_wsl_path(path)
+        is_ssh = data[1] if len(data) > 1 else False
+        ssh_host = data[2] if len(data) > 2 else None
+        ssh_user = data[3] if len(data) > 3 else None
+        ssh_port = data[4] if len(data) > 4 else None
 
-        label = "(WSL)" if is_wsl else "(Windows)"
+        if is_ssh:
+            label = f"(SSH: {ssh_host})"
+        elif is_wsl_path(path):
+            label = "(WSL)"
+        else:
+            label = "(Windows)"
 
         return [
             {
@@ -185,13 +254,25 @@ class ZedWorkspaceSearch(FlowLauncher):
                 "IcoPath": "assets/zed.png",
                 "JsonRPCAction": {
                     "method": "open_in_zed",
-                    "parameters": [path],
+                    "parameters": [path, is_ssh, ssh_host, ssh_user, ssh_port],
                 },
             }
         ]
 
-    def open_in_zed(self, path):
+    def open_in_zed(
+        self, path, is_ssh=False, ssh_host=None, ssh_user=None, ssh_port=None
+    ):
         """Open workspace using the appropriate environment."""
+        # SSH remote
+        if is_ssh and ssh_host:
+            ssh_uri = build_ssh_uri(ssh_host, path, ssh_user, ssh_port)
+            subprocess.Popen(
+                ["zed", ssh_uri],
+                shell=False,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            return
+
         if is_wsl_path(path):
             subprocess.Popen(
                 ["wsl", "zed", path],

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "ID": "91a89d52b8bd4a1ebfde9d09b7b5803b",
   "ActionKeyword": "z",
   "Name": "Zed Workspaces",
-  "Description": "Allows search for Zed workspaces, locally or on WSL.",
+  "Description": "Allows search for Zed workspaces: local, WSL, and SSH remote.",
   "Author": "Shubham Bhatnagar",
   "Version": "1.6",
   "Language": "python",


### PR DESCRIPTION
- Query remote_connections table to detect SSH vs WSL workspaces
- Open SSH remotes with zed ssh://[user@]host[:port]/path
- Fix WSL detection to only apply when not SSH remote
- Update UI labels: 'Project (SSH: hostname)' and 'Project (WSL)' with proper capitalization
- Update README and plugin.json to document SSH support